### PR TITLE
Downsize rds instances for lower environments

### DIFF
--- a/envs/dev-govcloud/main.tf
+++ b/envs/dev-govcloud/main.tf
@@ -1,6 +1,6 @@
 locals {
   # UPDATE: set this to your stack (dev,prod,imp, etc)
-  stack = "dev"
+  stack       = "dev"
   application = "common-services"
 
   # UPDATE: set this to the front facing fqdn of your installation
@@ -8,10 +8,11 @@ locals {
 }
 
 module "app" {
-  source = "../../modules/cms"
-  stack  = "${local.stack}"
-  fqdn   = "${local.fqdn}"
-  application = "${local.application}"
+  source       = "../../modules/cms"
+  stack        = "${local.stack}"
+  fqdn         = "${local.fqdn}"
+  application  = "${local.application}"
+  rds_instance = "db.m5.large"
 
   # Optional, install an ssh key
   aws_ssh_key_name = "circleci"

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -7,9 +7,10 @@ locals {
 }
 
 module "app" {
-  source = "../../modules/cms"
-  stack  = "${local.stack}"
-  fqdn   = "${local.fqdn}"
+  source       = "../../modules/cms"
+  stack        = "${local.stack}"
+  fqdn         = "${local.fqdn}"
+  rds_instance = "db.m5.large"
 
   # Optional, install an ssh key
   aws_ssh_key_name = "circleci"


### PR DESCRIPTION
We can save a little coin for CMS by downsizing our RDS instances for lower environments, which aren't heavily used.

# Testing
- [x] successfully downsized the RDS instance for circleci-dev